### PR TITLE
Split libevent compatability header into a separate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libev-green.svg)](https://anaconda.org/conda-forge/libev) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libev.svg)](https://anaconda.org/conda-forge/libev) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libev.svg)](https://anaconda.org/conda-forge/libev) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libev.svg)](https://anaconda.org/conda-forge/libev) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libev--libevent-green.svg)](https://anaconda.org/conda-forge/libev-libevent) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libev-libevent.svg)](https://anaconda.org/conda-forge/libev-libevent) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libev-libevent.svg)](https://anaconda.org/conda-forge/libev-libevent) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libev-libevent.svg)](https://anaconda.org/conda-forge/libev-libevent) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libev--static-green.svg)](https://anaconda.org/conda-forge/libev-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libev-static.svg)](https://anaconda.org/conda-forge/libev-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libev-static.svg)](https://anaconda.org/conda-forge/libev-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libev-static.svg)](https://anaconda.org/conda-forge/libev-static) |
 
 Installing libev
@@ -102,10 +103,10 @@ Installing `libev` from the `conda-forge` channel can be achieved by adding `con
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `libev, libev-static` can be installed with:
+Once the `conda-forge` channel has been enabled, `libev, libev-libevent, libev-static` can be installed with:
 
 ```
-conda install libev libev-static
+conda install libev libev-libevent libev-static
 ```
 
 It is possible to list all of the versions of `libev` available on your platform with:

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -1,9 +1,14 @@
+#!/usr/bin/env bash
+
 make install
 
-if [[ "$PKG_NAME" == *static ]]
-then
+if [[ "$PKG_NAME" == *static ]]; then
 	# relying on conda to dedup package
 	echo "Keeping all files, conda will dedupe"
 else
 	rm -rf ${PREFIX}/lib/libev.a
+fi
+
+if [[ "$PKG_NAME" != *-libevent ]]; then
+	rm "${PREFIX}/include/event.h"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,12 @@ outputs:
   - name: libev-libevent
     script: install.sh  # [unix]
     requirements:
+      build:
+        - libtool
+        - make  # [unix]
+        - {{ compiler('c') }}
+      host:
+        - {{ pin_subpackage('libev', exact=True) }}
       run:
         - {{ pin_subpackage('libev', exact=True) }}
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ outputs:
         # Check for headers.
         - test -f "${PREFIX}/include/ev.h"
         - test -f "${PREFIX}/include/ev++.h"
-        - test -f "${PREFIX}/include/event.h"
+        - test ! -f "${PREFIX}/include/event.h"
         - test ! -f "${PREFIX}/lib/libev.a"
         - test -f "${PREFIX}/lib/libev${SHLIBEXT}"  # [unix]
 
@@ -50,7 +50,22 @@ outputs:
         - {{ pin_subpackage('libev', exact=True) }}
     test:
       commands:
+        - test ! -f "${PREFIX}/include/event.h"
         - test -f "${PREFIX}/lib/libev.a"
+      host:
+        - {{ pin_subpackage('libev', exact=True) }}
+      run:
+        - {{ pin_subpackage('libev', exact=True) }}
+
+  - name: libev-libevent
+    script: install.sh  # [unix]
+    requirements:
+      run:
+        - {{ pin_subpackage('libev', exact=True) }}
+    test:
+      commands:
+        - test -f "${PREFIX}/include/event.h"
+
 
 about:
   home: http://software.schmorp.de/pkg/libev.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,11 +57,15 @@ outputs:
       run:
         - {{ pin_subpackage('libev', exact=True) }}
 
+  # Compatibility wrapper to enable programs which use the libevent event loop to link against libev
+  # Split into a separate package to prevent clobbering libevent
   - name: libev-libevent
     script: install.sh  # [unix]
     requirements:
       run:
         - {{ pin_subpackage('libev', exact=True) }}
+      run_constrained:
+        - libevent ==9999999999
     test:
       commands:
         - test -f "${PREFIX}/include/event.h"


### PR DESCRIPTION
`libev` contains a compatibility wrapper (`include/event.h`) to enable programs which use the `libevent` event loop to link against `libev`. This causes problems in environments which contain both packages:

```
Warning: File 'include/event.h' found in multiple packages: libevent-2.1.10-hcdb4288_2.tar.bz2, libev-4.33-h516909a_0.tar.bz2
```

Debian splits this file into it's own package ([`libev-libevent-dev`](https://packages.debian.org/stretch/all/libev-libevent-dev/filelist)) and I think this is the most sensible approach. This PR uses the same mechanism as is used to split the static libraries to make a `libev-libevent` package which conflicts with `libevent`.